### PR TITLE
Make etcd value preview panel vertical-scrollable

### DIFF
--- a/src/main/kotlin/com/github/tsonglew/etcdhelper/view/editor/EtcdValueDisplayPanel.kt
+++ b/src/main/kotlin/com/github/tsonglew/etcdhelper/view/editor/EtcdValueDisplayPanel.kt
@@ -176,6 +176,7 @@ class EtcdValueDisplayPanel : JPanel(BorderLayout()) {
                     isRefrainFromScrolling = false
                     isAnimatedScrolling = true
                 }
+                editor.setVerticalScrollbarVisible(true)
             }
         }
 


### PR DESCRIPTION
Hi. Thanks for your work of this plugin.

It seems that the value preview panels are not scrollable if the lines of etcd value exceeds the limits of preview panel.
This PR makes the panel scrollable and shows scrollbar if it is required.